### PR TITLE
Add schema quality tests and improve schema metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ npm run validate
 
 # Run comprehensive tests (214 tests)
 npm test
+
+# Run quality checks specifically (158 tests)
+npm run test:schema-quality
 ```
 
 **All schemas are validated with:**

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ npm install
 # Quick validation with visual feedback
 npm run validate
 
-# Run comprehensive tests (228 tests)
+# Run comprehensive tests
 npm test
 
-# Run quality checks specifically (158 tests)
+# Run quality checks specifically
 npm run test:schema-quality
 ```
 
 **All schemas are validated with:**
 
-- ✅ 70 technical compliance tests
-- ✅ 158 quality standard tests
+- ✅ Technical compliance tests
+- ✅ Quality standard tests
 - ✅ Real-time validation feedback
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 # Quick validation with visual feedback
 npm run validate
 
-# Run comprehensive tests (214 tests)
+# Run comprehensive tests (228 tests)
 npm test
 
 # Run quality checks specifically (158 tests)
@@ -45,7 +45,7 @@ npm run test:schema-quality
 
 **All schemas are validated with:**
 
-- ✅ 56 technical compliance tests
+- ✅ 70 technical compliance tests
 - ✅ 158 quality standard tests
 - ✅ Real-time validation feedback
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ npm run test:schema-quality
 - [Testing Guide](docs/testing-guide.md) - Validation tools
 - [Examples](examples/) - Real raga data _(coming soon)_
 
+---
+
 _Made with love for the global Indian classical music community_
 
 Copyright © 2025 OpenRaga Contributors

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Raga information is scattered across books, websites, and oral traditions with n
 ## Who Uses This
 
 - **Developers**: Build music apps with structured raga data
-- **Researchers**: Analyze ragas systematically  
+- **Researchers**: Analyze ragas systematically
 - **Musicians**: Access comprehensive raga information
 - **AI/ML**: Train models on cultural musical data
 
@@ -27,14 +27,31 @@ Raga information is scattered across books, websites, and oral traditions with n
 - **Flexibility**: Support for both Hindustani and Carnatic systems
 - **Extensibility**: Custom fields allowed with `x-` prefix
 
+## Quick Start
+
+```bash
+# Install dependencies
+npm install
+
+# Quick validation with visual feedback
+npm run validate
+
+# Run comprehensive tests (214 tests)
+npm test
+```
+
+**All schemas are validated with:**
+
+- ✅ 56 technical compliance tests
+- ✅ 158 quality standard tests
+- ✅ Real-time validation feedback
 
 ## Documentation
 
 - [Schema Reference](docs/) - Technical details
 - [Testing Guide](docs/testing-guide.md) - Validation tools
-- [Examples](examples/) - Real raga data *(coming soon)*
+- [Examples](examples/) - Real raga data _(coming soon)_
 
-
-*Made with love for the global Indian classical music community*
+_Made with love for the global Indian classical music community_
 
 Copyright © 2025 OpenRaga Contributors

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The RagaJSON testing system ensures validation of the project's JSON Schema files. This guarantees that all schemas are correctly written according to the JSON Schema draft-2020-12 specification.
+The RagaJSON testing system ensures comprehensive validation of the project's JSON Schema files. This guarantees that all schemas are correctly written according to the JSON Schema draft-2020-12 specification and meet high quality standards.
 
 ## Test Structure
 
@@ -81,7 +81,7 @@ This project uses three complementary validation approaches, following industry 
 
 - **Purpose**: Enforce quality standards and best practices
 - **Validates**: Metadata completeness, documentation quality, naming conventions
-- **Output**: Detailed quality reports with 158 comprehensive checks
+- **Output**: Detailed quality reports with comprehensive checks
 - **When to use**: Code reviews, maintaining high standards
 - **Focus**: Developer experience and maintainability
 
@@ -141,39 +141,52 @@ npm run test                  # All tests including quality
 
 ### Quality Standards (`npm run test:schema-quality`)
 
+#### 📋 Schema Structure Validation
+
+- ✅ Valid object structure
+- ✅ Required JSON Schema fields
+- ✅ Proper schema format validation
+
 #### 📝 Metadata Requirements
 
 - ✅ All required metadata fields present
 - ✅ Examples provided for enum schemas
 - ✅ Correct schema version usage
+- ✅ Meaningful descriptions
+- ✅ Proper capitalization and punctuation
 
 #### 🎯 Structure Consistency
 
 - ✅ Consistent `$id` pattern formatting
 - ✅ Enum schemas follow standard structure
 - ✅ Type schemas follow standard structure
+- ✅ Cross-schema consistency checks
 
 #### 🏷️ displayName and Custom Properties
 
 - ✅ `displayName` present for complex enums
 - ✅ Proper custom field patterns (x- prefix support)
+- ✅ Validation of enum display names
 
 #### 🔗 $ref Link Validation
 
 - ✅ All `$ref` links are valid and resolvable
 - ✅ Cross-references work within project
+- ✅ Local path validation
 
 #### 📚 Documentation Readiness
 
 - ✅ All properties have descriptive documentation
-- ✅ Meaningful enum descriptions (>20 characters)
+- ✅ Meaningful enum descriptions
 - ✅ All enum values properly documented
+- ✅ Description quality standards
 
 #### 🎨 Style and Formatting
 
 - ✅ Naming conventions followed (PascalCase titles)
 - ✅ Proper JSON formatting and indentation
 - ✅ Descriptions end with periods
+- ✅ Consistent style across all schemas
 
 ## Error Examples and Solutions
 
@@ -258,7 +271,7 @@ Expected $schema to be 'https://json-schema.org/draft/2020-12/schema', got 'http
 ```json
 {
   "title": "MyEnum",
-  "description": "A comprehensive enumeration of valid values for my specific use case." // ← make it >20 chars and end with period
+  "description": "A comprehensive enumeration of valid values for my specific use case." // ← make it meaningful and end with period
 }
 ```
 
@@ -381,11 +394,11 @@ When creating a new schema, follow these quality standards:
 ### 2. Quality Standards Checklist
 
 - ✅ **Title**: PascalCase, descriptive
-- ✅ **Description**: >20 characters, ends with period
+- ✅ **Description**: Meaningful, ends with period
 - ✅ **Examples**: Provided for all enum schemas
 - ✅ **displayName**: Added to all oneOf const values
 - ✅ **$id**: Uses correct GitHub raw URL pattern
-- ✅ **Properties**: All have meaningful descriptions >5 characters
+- ✅ **Properties**: All have meaningful descriptions
 
 ### 3. For Enum Schemas
 
@@ -428,7 +441,7 @@ npm test
 
 ### 5. Common Quality Issues to Avoid
 
-- ❌ Short descriptions (<20 chars)
+- ❌ Short or meaningless descriptions
 - ❌ Missing examples for enums
 - ❌ Missing displayName for oneOf const
 - ❌ Incorrect $id pattern

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -9,7 +9,7 @@ The RagaJSON testing system ensures comprehensive validation of the project's JS
 ```
 ragajson/
 ├── tests/
-│   ├── schema-validation.test.js    # Meta-validation tests
+│   ├── schema-validation.test.js    # Schema validation tests
 │   └── schema-quality.test.js       # Quality and best practices tests
 ├── scripts/
 │   └── validate-schemas.js          # Quick schema validation

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -9,7 +9,8 @@ The RagaJSON testing system ensures validation of the project's JSON Schema file
 ```
 ragajson/
 ├── tests/
-│   └── schema-validation.test.js    # Jest tests for schemas
+│   ├── schema-validation.test.js    # Meta-validation tests
+│   └── schema-quality.test.js       # Quality and best practices tests
 ├── scripts/
 │   └── validate-schemas.js          # Quick schema validation
 └── docs/
@@ -42,7 +43,8 @@ Runs a quick check of all schemas with visual output:
 ### Comprehensive Testing
 
 ```bash
-npm run test:schemas
+npm run test:schemas           # Basic schema validation
+npm run test:schema-quality    # Advanced quality checks
 ```
 
 Runs detailed Jest tests with comprehensive reports.
@@ -53,13 +55,13 @@ Runs detailed Jest tests with comprehensive reports.
 npm test
 ```
 
-Runs all project tests.
+Runs all project tests (validation + quality + any other tests).
 
-## Two Validation Approaches
+## Three-Tier Testing Strategy
 
-This project uses two complementary validation methods, following industry best practices:
+This project uses three complementary validation approaches, following industry best practices:
 
-### Quick Validation Script (`npm run validate`)
+### 1. Quick Validation Script (`npm run validate`)
 
 - **Purpose**: Fast feedback during development
 - **Output**: Visual, human-readable with emojis and colors
@@ -67,41 +69,57 @@ This project uses two complementary validation methods, following industry best 
 - **Audience**: Developers
 - **Performance**: Fast execution, immediate results
 
-### Jest Tests (`npm run test:schemas`)
+### 2. Schema Validation Tests (`npm run test:schemas`)
 
-- **Purpose**: Formal testing for CI/CD and comprehensive validation
-- **Output**: Structured test reports, detailed error information
-- **When to use**: CI/CD pipelines, pull requests, integration testing
-- **Audience**: Automation systems, test runners
-- **Performance**: More thorough, generates test coverage reports
+- **Purpose**: Formal JSON Schema compliance testing
+- **Validates**: Syntax, meta-schema compliance, $ref links
+- **Output**: Structured test reports for basic validation
+- **When to use**: CI/CD pipelines, ensuring schema correctness
+- **Focus**: Technical correctness
 
-### Why Both?
+### 3. Schema Quality Tests (`npm run test:schema-quality`)
 
-This dual approach provides several benefits:
+- **Purpose**: Enforce quality standards and best practices
+- **Validates**: Metadata completeness, documentation quality, naming conventions
+- **Output**: Detailed quality reports with 158 comprehensive checks
+- **When to use**: Code reviews, maintaining high standards
+- **Focus**: Developer experience and maintainability
+
+### Why Three Tiers?
+
+This comprehensive approach provides several benefits:
 
 1. **Developer Experience**: Quick script gives instant, visual feedback while coding
-2. **Automation Integration**: Jest tests integrate seamlessly with CI/CD systems
-3. **Different Detail Levels**: Script for overview, tests for deep analysis
-4. **Flexibility**: Use separately during development or together in pipelines
-5. **Industry Standard**: Common pattern used by major projects (ESLint, Prettier, TypeScript)
+2. **Technical Assurance**: Validation tests ensure schemas meet JSON Schema standards
+3. **Quality Standards**: Quality tests enforce documentation and maintainability best practices
+4. **Automation Integration**: Jest tests integrate seamlessly with CI/CD systems
+5. **Gradual Validation**: From quick checks to deep quality analysis
+6. **Industry Standard**: Layered testing pattern used by major projects
 
 ### Example Workflow
 
 ```bash
 # During development
-npm run validate              # Quick check
+npm run validate              # Quick visual check
 
 # Before committing
-npm run validate && git commit
+npm run validate && \
+npm run test:schemas && \
+git commit
+
+# Code review process
+npm run test:schema-quality   # Comprehensive quality checks
 
 # In CI/CD pipeline
 npm run validate              # Fast gate check
-npm run test:schemas          # Detailed validation
+npm run test                  # All tests including quality
 ```
 
 ## What is Tested
 
-### 1. File Structure
+### Basic Validation (`npm run test:schemas`)
+
+#### 1. File Structure
 
 - ✅ Valid JSON syntax
 - ✅ Presence of required fields:
@@ -110,20 +128,58 @@ npm run test:schemas          # Detailed validation
   - `title` (schema name)
   - `description` (schema description)
 
-### 2. Meta-Validation
+#### 2. Meta-Validation
 
 - ✅ Compliance with JSON Schema draft-2020-12
 - ✅ Correct data types
 - ✅ Proper keyword syntax
 
-### 3. $ref Links
+#### 3. $ref Links
 
 - ✅ All local `$ref` links exist
 - ✅ File paths are correct
 
+### Quality Standards (`npm run test:schema-quality`)
+
+#### 📝 Metadata Requirements
+
+- ✅ All required metadata fields present
+- ✅ Examples provided for enum schemas
+- ✅ Correct schema version usage
+
+#### 🎯 Structure Consistency
+
+- ✅ Consistent `$id` pattern formatting
+- ✅ Enum schemas follow standard structure
+- ✅ Type schemas follow standard structure
+
+#### 🏷️ displayName and Custom Properties
+
+- ✅ `displayName` present for complex enums
+- ✅ Proper custom field patterns (x- prefix support)
+
+#### 🔗 $ref Link Validation
+
+- ✅ All `$ref` links are valid and resolvable
+- ✅ Cross-references work within project
+
+#### 📚 Documentation Readiness
+
+- ✅ All properties have descriptive documentation
+- ✅ Meaningful enum descriptions (>20 characters)
+- ✅ All enum values properly documented
+
+#### 🎨 Style and Formatting
+
+- ✅ Naming conventions followed (PascalCase titles)
+- ✅ Proper JSON formatting and indentation
+- ✅ Descriptions end with periods
+
 ## Error Examples and Solutions
 
-### Missing Required Field
+### Basic Validation Errors
+
+#### Missing Required Field
 
 **Error:**
 
@@ -139,13 +195,13 @@ npm run test:schemas          # Detailed validation
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/my_enum.json",
   "title": "MyEnum", // ← add this
-  "description": "Description of my enum",
+  "description": "Description of my enum.",
   "type": "string",
   "enum": ["value1", "value2"]
 }
 ```
 
-### Incorrect Schema Version
+#### Incorrect Schema Version
 
 **Error:**
 
@@ -162,37 +218,81 @@ Expected $schema to be 'https://json-schema.org/draft/2020-12/schema', got 'http
 }
 ```
 
-### Broken $ref Link
+### Quality Standard Errors
+
+#### Missing displayName for Complex Enums
 
 **Error:**
 
 ```
-$ref link not found: schema/components/nonexistent_enum.json
-```
-
-**Solution:**
-
-1. Create the missing file
-2. Or fix the path in `$ref`
-
-### Invalid JSON Schema Syntax
-
-**Error:**
-
-```
-root: must have property 'type'
+✕ schema/components/my_enum.json should have displayName for complex enums
 ```
 
 **Solution:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "...",
-  "title": "...",
-  "description": "...",
-  "type": "string", // ← add required property
-  "enum": ["value1", "value2"]
+  "oneOf": [
+    {
+      "const": "value1",
+      "displayName": "Value One" // ← add this
+    },
+    {
+      "const": "value2",
+      "displayName": "Value Two" // ← add this
+    }
+  ]
+}
+```
+
+#### Description Quality Issues
+
+**Error:**
+
+```
+✕ schema/components/my_enum.json should have meaningful enum descriptions
+```
+
+**Solution:**
+
+```json
+{
+  "title": "MyEnum",
+  "description": "A comprehensive enumeration of valid values for my specific use case." // ← make it >20 chars and end with period
+}
+```
+
+#### Missing Examples
+
+**Error:**
+
+```
+✕ schema/components/my_enum.json should have examples where appropriate
+```
+
+**Solution:**
+
+```json
+{
+  "type": "string",
+  "enum": ["value1", "value2"],
+  "examples": ["value1", "value2"] // ← add this
+}
+```
+
+#### Incorrect $id Pattern
+
+**Error:**
+
+```
+✕ schema/components/my_enum.json should have consistent $id pattern
+```
+
+**Solution:**
+
+```json
+{
+  "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/my_enum.json" // ← use correct pattern
 }
 ```
 
@@ -212,7 +312,7 @@ The validator uses AJV with these settings:
 
 ## CI/CD Integration
 
-Add schema validation to your CI pipeline:
+Add comprehensive schema validation to your CI pipeline:
 
 ```yaml
 # .github/workflows/test.yml
@@ -227,48 +327,154 @@ jobs:
         with:
           node-version: "18"
       - run: npm ci
+      - run: npm run validate # Quick validation
+      - run: npm run test:schemas # Technical validation
+      - run: npm run test:schema-quality # Quality standards
+```
+
+### Staged Pipeline (Recommended)
+
+For faster feedback, consider a staged approach:
+
+```yaml
+jobs:
+  quick-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm ci
       - run: npm run validate
-      - run: npm run test:schemas
+
+  comprehensive-test:
+    needs: quick-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm ci
+      - run: npm test # All tests including quality
 ```
 
 ## Adding New Schemas
 
-When creating a new schema, make sure that:
+When creating a new schema, follow these quality standards:
 
-1. **File has the correct structure:**
+### 1. Basic Structure Requirements
 
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/path/to/your_schema.json",
   "title": "YourSchemaName",
-  "description": "Clear description of what this schema validates",
-  "type": "string|object|array"
+  "description": "Clear, detailed description ending with a period.",
+  "type": "string|object|array",
+  "examples": ["example1", "example2"] // Required for enums
   // ... your schema
 }
 ```
 
-2. **Run validation:**
+### 2. Quality Standards Checklist
+
+- ✅ **Title**: PascalCase, descriptive
+- ✅ **Description**: >20 characters, ends with period
+- ✅ **Examples**: Provided for all enum schemas
+- ✅ **displayName**: Added to all oneOf const values
+- ✅ **$id**: Uses correct GitHub raw URL pattern
+- ✅ **Properties**: All have meaningful descriptions >5 characters
+
+### 3. For Enum Schemas
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/my_enum.json",
+  "title": "MyEnum",
+  "description": "A comprehensive enumeration of valid values for specific use case.",
+  "type": "string",
+  "oneOf": [
+    {
+      "const": "value1",
+      "displayName": "Display Name One"
+    },
+    {
+      "const": "value2",
+      "displayName": "Display Name Two"
+    }
+  ],
+  "examples": ["value1", "value2"]
+}
+```
+
+### 4. Validation Steps
 
 ```bash
+# Step 1: Quick check
 npm run validate
-```
 
-3. **Check tests:**
-
-```bash
+# Step 2: Technical validation
 npm run test:schemas
+
+# Step 3: Quality validation
+npm run test:schema-quality
+
+# Step 4: Full test suite
+npm test
 ```
+
+### 5. Common Quality Issues to Avoid
+
+- ❌ Short descriptions (<20 chars)
+- ❌ Missing examples for enums
+- ❌ Missing displayName for oneOf const
+- ❌ Incorrect $id pattern
+- ❌ Descriptions not ending with periods
 
 ## Debugging
 
-For detailed error analysis, use Jest tests:
+### For Basic Validation Issues
 
 ```bash
 npm run test:schemas -- --verbose
 ```
 
-This will show detailed information about each test and error.
+### For Quality Standard Issues
+
+```bash
+npm run test:schema-quality -- --verbose
+```
+
+### For Specific Schema Debugging
+
+```bash
+# Test only one file
+npm run test:schema-quality -- --testNamePattern="schema/components/my_enum.json"
+
+# Show all error details
+npm run test:schema-quality -- --verbose --no-coverage
+```
+
+### Common Debugging Commands
+
+```bash
+# Quick visual check
+npm run validate
+
+# Detailed technical validation
+npm run test:schemas -- --verbose
+
+# Comprehensive quality analysis
+npm run test:schema-quality -- --verbose
+
+# All tests with maximum detail
+npm test -- --verbose --detectOpenHandles
+```
+
+This will show detailed information about each test, error messages, and quality violations.
 
 ## Useful Links
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -386,7 +386,7 @@ When creating a new schema, follow these quality standards:
   "title": "YourSchemaName",
   "description": "Clear, detailed description ending with a period.",
   "type": "string|object|array",
-  "examples": ["example1", "example2"] // Required for enums
+  "examples": ["example1", "example2"]
   // ... your schema
 }
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "format:json": "prettier --write \"**/*.json\"",
     "validate": "node scripts/validate-schemas.js",
     "test": "jest",
-    "test:schemas": "jest tests/schema-validation.test.js"
+    "test:schemas": "jest tests/schema-validation.test.js",
+    "test:quality": "jest tests/schema-quality.test.js"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "validate": "node scripts/validate-schemas.js",
     "test": "jest",
     "test:schemas": "jest tests/schema-validation.test.js",
-    "test:quality": "jest tests/schema-quality.test.js"
+    "test:schema-quality": "jest tests/schema-quality.test.js"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/schema/components/jaati_enum.json
+++ b/schema/components/jaati_enum.json
@@ -7,38 +7,47 @@
   "oneOf": [
     {
       "const": "Audava-Audava",
+      "displayName": "Audava-Audava",
       "description": "5 notes in aroha, 5 notes in avaroha"
     },
     {
       "const": "Audava-Shadava",
+      "displayName": "Audava-Shadava",
       "description": "5 notes in aroha, 6 notes in avaroha"
     },
     {
       "const": "Audava-Sampurna",
+      "displayName": "Audava-Sampurna",
       "description": "5 notes in aroha, 7 notes in avaroha"
     },
     {
       "const": "Shadava-Audava",
+      "displayName": "Shadava-Audava",
       "description": "6 notes in aroha, 5 notes in avaroha"
     },
     {
       "const": "Shadava-Shadava",
+      "displayName": "Shadava-Shadava",
       "description": "6 notes in aroha, 6 notes in avaroha"
     },
     {
       "const": "Shadava-Sampurna",
+      "displayName": "Shadava-Sampurna",
       "description": "6 notes in aroha, 7 notes in avaroha"
     },
     {
       "const": "Sampurna-Audava",
+      "displayName": "Sampurna-Audava",
       "description": "7 notes in aroha, 5 notes in avaroha"
     },
     {
       "const": "Sampurna-Shadava",
+      "displayName": "Sampurna-Shadava",
       "description": "7 notes in aroha, 6 notes in avaroha"
     },
     {
       "const": "Sampurna-Sampurna",
+      "displayName": "Sampurna-Sampurna",
       "description": "7 notes in aroha, 7 notes in avaroha"
     }
   ],

--- a/schema/components/jaati_enum.json
+++ b/schema/components/jaati_enum.json
@@ -8,47 +8,47 @@
     {
       "const": "Audava-Audava",
       "displayName": "Audava-Audava",
-      "description": "5 notes in aroha, 5 notes in avaroha"
+      "description": "5 notes in aroha, 5 notes in avaroha."
     },
     {
       "const": "Audava-Shadava",
       "displayName": "Audava-Shadava",
-      "description": "5 notes in aroha, 6 notes in avaroha"
+      "description": "5 notes in aroha, 6 notes in avaroha."
     },
     {
       "const": "Audava-Sampurna",
       "displayName": "Audava-Sampurna",
-      "description": "5 notes in aroha, 7 notes in avaroha"
+      "description": "5 notes in aroha, 7 notes in avaroha."
     },
     {
       "const": "Shadava-Audava",
       "displayName": "Shadava-Audava",
-      "description": "6 notes in aroha, 5 notes in avaroha"
+      "description": "6 notes in aroha, 5 notes in avaroha."
     },
     {
       "const": "Shadava-Shadava",
       "displayName": "Shadava-Shadava",
-      "description": "6 notes in aroha, 6 notes in avaroha"
+      "description": "6 notes in aroha, 6 notes in avaroha."
     },
     {
       "const": "Shadava-Sampurna",
       "displayName": "Shadava-Sampurna",
-      "description": "6 notes in aroha, 7 notes in avaroha"
+      "description": "6 notes in aroha, 7 notes in avaroha."
     },
     {
       "const": "Sampurna-Audava",
       "displayName": "Sampurna-Audava",
-      "description": "7 notes in aroha, 5 notes in avaroha"
+      "description": "7 notes in aroha, 5 notes in avaroha."
     },
     {
       "const": "Sampurna-Shadava",
       "displayName": "Sampurna-Shadava",
-      "description": "7 notes in aroha, 6 notes in avaroha"
+      "description": "7 notes in aroha, 6 notes in avaroha."
     },
     {
       "const": "Sampurna-Sampurna",
       "displayName": "Sampurna-Sampurna",
-      "description": "7 notes in aroha, 7 notes in avaroha"
+      "description": "7 notes in aroha, 7 notes in avaroha."
     }
   ],
   "examples": ["Audava-Audava", "Audava-Sampurna", "Sampurna-Sampurna"]

--- a/schema/raga.schema.json
+++ b/schema/raga.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/raga.schema.json",
   "title": "RagaJSON Schema",
-  "description": "Machine-readable schema for describing ragas of Indian classical music",
+  "description": "Machine-readable schema for describing ragas of Indian classical music.",
   "type": "object",
   "properties": {
     "name": {
@@ -10,20 +10,24 @@
       "description": "Raga name"
     },
     "system": {
-      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/system_enum.json"
+      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/system_enum.json",
+      "description": "Indian classical music system (Hindustani or Carnatic)."
     },
     "classification": {
       "type": "string",
       "description": "Raga classification"
     },
     "structure": {
-      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/structure_type.json"
+      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/structure_type.json",
+      "description": "Structural parameters of the raga (notes, patterns, etc.)."
     },
     "performance": {
-      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/performance_type.json"
+      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/performance_type.json",
+      "description": "Performance-related information (time, season, rasa, etc.)."
     },
     "examples": {
-      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/examples_type.json"
+      "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/examples_type.json",
+      "description": "Audio, video, and composition examples of the raga."
     },
     "custom": {
       "type": "object",

--- a/schema/raga.schema.json
+++ b/schema/raga.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "description": "Raga name"
+      "description": "Raga name."
     },
     "system": {
       "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/components/system_enum.json",

--- a/schema/raga.schema.json
+++ b/schema/raga.schema.json
@@ -15,7 +15,7 @@
     },
     "classification": {
       "type": "string",
-      "description": "Raga classification"
+      "description": "Raga classification."
     },
     "structure": {
       "$ref": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/structure_type.json",

--- a/schema/types/performance_type.json
+++ b/schema/types/performance_type.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/performance_type.json",
   "title": "PerformanceType",
-  "description": "Raga performance parameters (form, tempo, time of day, etc.)",
+  "description": "Raga performance parameters (form, tempo, time of day, etc.).",
   "type": "object",
   "properties": {
     "form": {

--- a/schema/types/rasa_entry_type.json
+++ b/schema/types/rasa_entry_type.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/rasa_entry_type.json",
   "title": "RasaEntryType",
-  "description": "Rasa entry with weight (intensity)",
+  "description": "Rasa entry with weight (intensity).",
   "type": "object",
   "properties": {
     "rasa": {

--- a/schema/types/structure_type.json
+++ b/schema/types/structure_type.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/OpenRaga/ragajson/main/schema/types/structure_type.json",
   "title": "StructureType",
-  "description": "Structural parameters of a raga (e.g., aroha, avaroha, svaras, etc.)",
+  "description": "Structural parameters of a raga (e.g., aroha, avaroha, svaras, etc.).",
   "type": "object",
   "properties": {
     "aroha": {

--- a/tests/schema-quality.test.js
+++ b/tests/schema-quality.test.js
@@ -1,0 +1,312 @@
+const Ajv = require("ajv")
+const addFormats = require("ajv-formats")
+const fs = require("fs")
+const path = require("path")
+const glob = require("glob")
+
+describe("JSON Schema Quality Check", () => {
+  let ajv
+  const schemaFiles = glob.sync("schema/**/*.json")
+
+  beforeAll(() => {
+    ajv = new Ajv({
+      strict: false,
+      allErrors: true,
+      validateSchema: false
+    })
+    addFormats(ajv)
+  })
+
+  describe("📝 Metadata Requirements", () => {
+    test.each(schemaFiles)("%s should have all required metadata fields", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      // Required fields
+      expect(schema.$schema).toBeDefined()
+      expect(schema.$id).toBeDefined()
+      expect(schema.title).toBeDefined()
+      expect(schema.description).toBeDefined()
+      expect(schema.type).toBeDefined()
+      
+      // Metadata quality check
+      expect(schema.title).toMatch(/^[A-Z][a-zA-Z\s]*$/) // Allow spaces
+      expect(schema.description.length).toBeGreaterThan(10) // Detailed description
+      expect(schema.description).toMatch(/^[A-Z]/) // Starts with capital letter
+      expect(schema.description).toMatch(/\.$/) // Ends with period
+    })
+
+    test.each(schemaFiles)("%s should have examples where appropriate", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      // Enum schemas should have examples
+      if (schema.enum || schema.oneOf) {
+        expect(schema.examples).toBeDefined()
+        expect(Array.isArray(schema.examples)).toBe(true)
+        expect(schema.examples.length).toBeGreaterThan(0)
+      }
+    })
+
+    test.each(schemaFiles)("%s should use correct schema version", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      expect(schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema")
+    })
+  })
+
+  describe("🎯 Structure Consistency", () => {
+    test.each(schemaFiles)("%s should have consistent $id pattern", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      const expectedId = `https://raw.githubusercontent.com/OpenRaga/ragajson/main/${filePath}`
+      expect(schema.$id).toBe(expectedId)
+    })
+
+    test("enum schemas should have consistent structure", () => {
+      const enumFiles = schemaFiles.filter(file => file.includes("_enum.json"))
+      
+      enumFiles.forEach(filePath => {
+        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        
+        // Enum schemas should have either 'enum' or 'oneOf'
+        expect(schema.enum || schema.oneOf).toBeDefined()
+        
+        // Should have examples
+        expect(schema.examples).toBeDefined()
+        
+        // Should have type string
+        expect(schema.type).toBe("string")
+      })
+    })
+
+    test("type schemas should have consistent structure", () => {
+      const typeFiles = schemaFiles.filter(file => file.includes("_type.json"))
+      
+      typeFiles.forEach(filePath => {
+        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        
+        // Type schemas should have 'type': 'object' or be more complex
+        expect(schema.type === "object" || schema.oneOf || schema.anyOf).toBe(true)
+        
+        // Should have properties defined if it's an object
+        if (schema.type === "object") {
+          expect(schema.properties).toBeDefined()
+          expect(typeof schema.properties).toBe("object")
+        }
+      })
+    })
+  })
+
+  describe("🏷️ displayName and Custom Properties", () => {
+    test.each(schemaFiles)("%s should have displayName for complex enums", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      // If there's oneOf with const, displayName should be present
+      if (schema.oneOf && Array.isArray(schema.oneOf)) {
+        schema.oneOf.forEach(item => {
+          if (item.const) {
+            expect(item.displayName).toBeDefined()
+            expect(typeof item.displayName).toBe("string")
+            expect(item.displayName.length).toBeGreaterThan(0)
+          }
+        })
+      }
+    })
+
+    test.each(schemaFiles)("%s should have proper custom field patterns", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      function checkCustomPatterns(obj) {
+        if (typeof obj !== "object" || obj === null) return
+        
+        if (obj.custom) {
+          expect(obj.custom.patternProperties).toBeDefined()
+          expect(obj.custom.patternProperties["^x-"]).toBeDefined()
+          expect(obj.custom.additionalProperties).toBe(false)
+        }
+        
+        // Recursively check nested objects
+        for (const key in obj) {
+          if (typeof obj[key] === "object") {
+            checkCustomPatterns(obj[key])
+          }
+        }
+      }
+      
+      checkCustomPatterns(schema)
+    })
+  })
+
+  describe("🔗 $ref Link Validation", () => {
+    test.each(schemaFiles)("%s should have valid $ref links", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      const refs = extractRefs(schema)
+      
+      refs.forEach(ref => {
+        if (ref.startsWith("https://raw.githubusercontent.com/OpenRaga/ragajson/main/")) {
+          const localPath = ref.replace(
+            "https://raw.githubusercontent.com/OpenRaga/ragajson/main/",
+            ""
+          )
+          
+          expect(fs.existsSync(localPath)).toBe(true)
+          
+          // Check that file is valid JSON
+          expect(() => {
+            JSON.parse(fs.readFileSync(localPath, "utf8"))
+          }).not.toThrow()
+        }
+      })
+    })
+
+    test("all $ref links should be resolvable within project", () => {
+      const allRefs = new Set()
+      
+      schemaFiles.forEach(filePath => {
+        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        const refs = extractRefs(schema)
+        refs.forEach(ref => allRefs.add(ref))
+      })
+      
+      allRefs.forEach(ref => {
+        if (ref.startsWith("https://raw.githubusercontent.com/OpenRaga/ragajson/main/")) {
+          const localPath = ref.replace(
+            "https://raw.githubusercontent.com/OpenRaga/ragajson/main/",
+            ""
+          )
+          
+          expect(fs.existsSync(localPath)).toBe(true)
+        }
+      })
+    })
+  })
+
+  describe("📚 Documentation Readiness", () => {
+    test.each(schemaFiles)("%s should have descriptive properties", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      function checkDescriptions(obj, path = "") {
+        if (typeof obj !== "object" || obj === null) return
+        
+        if (obj.properties) {
+          for (const [propName, propSchema] of Object.entries(obj.properties)) {
+            if (propName !== "custom" && typeof propSchema === "object") {
+              const currentPath = path ? `${path}.${propName}` : propName
+              
+              // Skip checking descriptions for properties that only have $ref
+              if (propSchema.$ref && !propSchema.description) {
+                continue
+              }
+              
+              if (!propSchema.description) {
+                throw new Error(`Property ${currentPath} missing description`)
+              }
+              
+              expect(propSchema.description).toBeDefined()
+              expect(propSchema.description.length).toBeGreaterThan(5)
+            }
+          }
+        }
+        
+        // Skip checking inside if/then/else blocks and other structural elements
+        const skipKeys = new Set(["if", "then", "else", "allOf", "anyOf", "oneOf", "not", "examples", "enum", "const"])
+        
+        // Recursively check nested objects
+        for (const key in obj) {
+          if (typeof obj[key] === "object" && !skipKeys.has(key)) {
+            checkDescriptions(obj[key], path ? `${path}.${key}` : key)
+          }
+        }
+      }
+      
+      checkDescriptions(schema)
+    })
+
+    test.each(schemaFiles)("%s should have meaningful enum descriptions", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      if (schema.enum) {
+        // Simple enums should have detailed descriptions
+        expect(schema.description).toBeDefined()
+        expect(schema.description.length).toBeGreaterThan(20)
+      }
+      
+      if (schema.oneOf) {
+        // oneOf enums should have displayName for each variant
+        schema.oneOf.forEach((item, index) => {
+          if (item.const) {
+            expect(item.displayName).toBeDefined()
+          }
+        })
+      }
+    })
+
+    test("all enum values should be properly documented", () => {
+      const enumFiles = schemaFiles.filter(file => file.includes("_enum.json"))
+      
+      enumFiles.forEach(filePath => {
+        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        
+        if (schema.enum) {
+          // Check that all enum values are in examples
+          const enumValues = schema.enum
+          const exampleValues = schema.examples || []
+          
+          expect(exampleValues.length).toBeGreaterThan(0)
+          
+          // All examples should be valid enum values
+          exampleValues.forEach(example => {
+            expect(enumValues).toContain(example)
+          })
+        }
+      })
+    })
+  })
+
+  describe("🎨 Style and Formatting", () => {
+    test.each(schemaFiles)("%s should follow naming conventions", filePath => {
+      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+      
+      // Title should be PascalCase
+      expect(schema.title).toMatch(/^[A-Z][a-zA-Z\s]*$/)
+      
+      // Description should be a proper sentence
+      expect(schema.description).toMatch(/^[A-Z]/)
+      expect(schema.description).toMatch(/\.$/)
+      
+      // File name should match content type
+      const fileName = path.basename(filePath, ".json")
+      if (fileName.includes("_enum")) {
+        expect(schema.title).toMatch(/Enum$/)
+      } else if (fileName.includes("_type")) {
+        expect(schema.title).toMatch(/Type$/)
+      }
+    })
+
+    test.each(schemaFiles)("%s should have proper JSON formatting", filePath => {
+      const content = fs.readFileSync(filePath, "utf8")
+      
+      // Should be valid JSON
+      expect(() => JSON.parse(content)).not.toThrow()
+      
+      // Should not have trailing commas or other formatting issues
+      expect(content).not.toMatch(/,\s*[}\]]/)
+    })
+  })
+})
+
+// Utility functions
+function extractRefs(obj, refs = []) {
+  if (typeof obj === "object" && obj !== null) {
+    if (obj.$ref && typeof obj.$ref === "string") {
+      refs.push(obj.$ref)
+    }
+
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        extractRefs(obj[key], refs)
+      }
+    }
+  }
+
+  return refs
+} 

--- a/tests/schema-quality.test.js
+++ b/tests/schema-quality.test.js
@@ -6,23 +6,23 @@ const glob = require("glob")
 
 // Generalized utility function for traversing objects with circular reference protection
 function traverse(obj, callback, options = {}) {
-  const { visited = new WeakSet(), currentPath = "", skipKeys = [] } = options;
-  
-  if (typeof obj !== "object" || obj === null) return;
+  const { visited = new WeakSet(), currentPath = "", skipKeys = [] } = options
+
+  if (typeof obj !== "object" || obj === null) return
 
   // Prevent infinite recursion
-  if (visited.has(obj)) return;
-  visited.add(obj);
+  if (visited.has(obj)) return
+  visited.add(obj)
 
   // Apply callback to current object
-  callback(obj, currentPath);
+  callback(obj, currentPath)
 
   // Recursively traverse nested objects
   for (const key in obj) {
-    if (skipKeys.includes(key)) continue; // Skip specified keys
+    if (skipKeys.includes(key)) continue // Skip specified keys
     if (typeof obj[key] === "object") {
-      const newPath = currentPath ? `${currentPath}.${key}` : key;
-      traverse(obj[key], callback, { visited, currentPath: newPath, skipKeys });
+      const newPath = currentPath ? `${currentPath}.${key}` : key
+      traverse(obj[key], callback, { visited, currentPath: newPath, skipKeys })
     }
   }
 }
@@ -259,7 +259,7 @@ describe("JSON Schema Quality Check", () => {
       // Use custom traversal for this case because we need to skip certain keys
       const skipKeys = [
         "if",
-        "then", 
+        "then",
         "else",
         "allOf",
         "anyOf",
@@ -268,7 +268,7 @@ describe("JSON Schema Quality Check", () => {
         "examples",
         "enum",
         "const"
-      ];
+      ]
 
       traverse(schema, handleDescriptions, { skipKeys })
     })

--- a/tests/schema-quality.test.js
+++ b/tests/schema-quality.test.js
@@ -18,13 +18,13 @@ function traverse(obj, callback, options = {}) {
   callback(obj, currentPath)
 
   // Recursively traverse nested objects
-  for (const key in obj) {
-    if (skipKeys.includes(key)) continue // Skip specified keys
+  Object.keys(obj).forEach(key => {
+    if (skipKeys.includes(key)) return // Skip specified keys
     if (typeof obj[key] === "object") {
       const newPath = currentPath ? `${currentPath}.${key}` : key
       traverse(obj[key], callback, { visited, currentPath: newPath, skipKeys })
     }
-  }
+  })
 }
 
 describe("JSON Schema Quality Check", () => {

--- a/tests/schema-quality.test.js
+++ b/tests/schema-quality.test.js
@@ -73,7 +73,7 @@ describe("JSON Schema Quality Check", () => {
       const enumFiles = schemaFiles.filter(file => file.includes("_enum.json"))
       
       enumFiles.forEach(filePath => {
-        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        const schema = schemaCache.get(filePath)
         
         // Enum schemas should have either 'enum' or 'oneOf'
         expect(schema.enum || schema.oneOf).toBeDefined()
@@ -90,7 +90,7 @@ describe("JSON Schema Quality Check", () => {
       const typeFiles = schemaFiles.filter(file => file.includes("_type.json"))
       
       typeFiles.forEach(filePath => {
-        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        const schema = schemaCache.get(filePath)
         
         // Type schemas should have 'type': 'object' or be more complex
         expect(schema.type === "object" || schema.oneOf || schema.anyOf).toBe(true)
@@ -172,7 +172,7 @@ describe("JSON Schema Quality Check", () => {
       const allRefs = new Set()
       
       schemaFiles.forEach(filePath => {
-        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        const schema = schemaCache.get(filePath)
         const refs = extractRefs(schema)
         refs.forEach(ref => allRefs.add(ref))
       })
@@ -258,7 +258,7 @@ describe("JSON Schema Quality Check", () => {
       const enumFiles = schemaFiles.filter(file => file.includes("_enum.json"))
       
       enumFiles.forEach(filePath => {
-        const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
+        const schema = schemaCache.get(filePath)
         
         if (schema.enum) {
           // Check that all enum values are in examples
@@ -315,7 +315,7 @@ function extractRefs(obj, refs = []) {
     }
 
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
         extractRefs(obj[key], refs)
       }
     }

--- a/tests/schema-quality.test.js
+++ b/tests/schema-quality.test.js
@@ -59,9 +59,7 @@ describe("JSON Schema Quality Check", () => {
   })
 
   describe("📋 Schema Structure Validation", () => {
-    test.each(schemaFiles)("validate schema structure for %s", filePath => {
-      const schema = JSON.parse(fs.readFileSync(filePath, "utf8"))
-
+    test.each(cachedSchemas)("validate schema structure for %s", ({ filePath, schema }) => {
       // Basic schema validation
       expect(typeof schema).toBe("object")
       expect(schema).not.toBeNull()
@@ -70,7 +68,7 @@ describe("JSON Schema Quality Check", () => {
       // Check required JSON Schema fields
       const requiredFields = ["$schema", "$id", "type", "title", "description"]
       requiredFields.forEach(field => {
-        expect(schema[field]).toBeDefined()
+        expect(schema).toHaveProperty(field)
       })
 
       // Validate $schema format
@@ -128,9 +126,6 @@ describe("JSON Schema Quality Check", () => {
 
         // Enum schemas should have either 'enum' or 'oneOf'
         expect(schema.enum || schema.oneOf).toBeDefined()
-
-        // Should have examples
-        expect(schema.examples).toBeDefined()
 
         // Should have type string
         expect(schema.type).toBe("string")


### PR DESCRIPTION
Introduces tests/schema-quality.test.js to enforce JSON schema quality, metadata completeness, $ref link validity, and style conventions. Updates schema files to improve descriptions, add displayName fields to jaati_enum, and ensure consistent formatting and documentation. Adds a new npm script 'test:quality' for running the new quality tests.